### PR TITLE
Make `GitHelper.pr_title` return just the title of the PR without the PR description, addressing Bitrise environment

### DIFF
--- a/fastlane/helpers/git_helper.rb
+++ b/fastlane/helpers/git_helper.rb
@@ -49,7 +49,7 @@ class GitHelper
       "CHANGE_TITLE", # Jenkins
     ]
     # For Bitrise it will retrieve the title + description as per the docs.
-    # Retrieving the first line will assert that only the Title will be retrieved.
+    # Retrieving the first line will assert that only the title will be retrieved.
     title = first_env_var_value_or_nil(pull_request_title_env_var_candidates)
     return title.lines.first.chomp unless title.nil?
   end

--- a/fastlane/helpers/git_helper.rb
+++ b/fastlane/helpers/git_helper.rb
@@ -45,10 +45,13 @@ class GitHelper
   # The title of the PR, e.g. "[Tools] Integrate fastlane"
   def self.pr_title
     pull_request_title_env_var_candidates = [
-      "BITRISE_GIT_MESSAGE", # Bitrise - May be the commit message instead of the PR title
+      "BITRISE_GIT_MESSAGE", # Bitrise
       "CHANGE_TITLE", # Jenkins
     ]
-    first_env_var_value_or_nil(pull_request_title_env_var_candidates)
+    # For Bitrise it will retrieve the title + description as per the docs.
+    # Retrieving the first line will assert that only the Title will be retrieved.
+    title = first_env_var_value_or_nil(pull_request_title_env_var_candidates)
+    return title.lines.first.chomp unless title.nil?
   end
 
   # The display name of the author of the PR e.g. "Roger Oba"


### PR DESCRIPTION
[As per the Bitrise documentation](https://devcenter.bitrise.io/en/references/available-environment-variables.html) the `BITRISE_GIT_MESSAGE` key will return `The commit message, pull request title, or the message you specified if you triggered the build manually.`
What it does in fact is return the `tile` (first line) + `description` of your PR.

In this quick fix I retrieve only the first line of the retrieved `string` and clean it up to have only the first line. (a.k.a. only the title)